### PR TITLE
Fix - Change the trust policy to a condition

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -73,10 +73,12 @@ resources:
           Statement:
           - Sid: AWSRDSEvents
             Effect: Allow
-            Principal:
-              Service: rds.amazonaws.com
+            Principal: "*"
             Action: sns:Publish
             Resource: !Ref RdsEventTopic
+            Condition:
+              ArnLike:
+                AWS:SourceArn: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:*"
         Topics:
         - !Ref RdsEventTopic
 


### PR DESCRIPTION
Change the trust policy to a condition according to [SNS documentation](https://docs.aws.amazon.com/sns/latest/dg/sns-access-policy-use-cases.html), that is the way to do it to trust only a service.