### PR TITLE
INFRA-5044 Add dependabot and CODEOWNERS to infra repos

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @PokaInc/infrastructure

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: monthly
+    groups:
+      python-deps:
+        patterns:
+          - "*"
+        # Major updates will have individual PRs
+        update-types:
+          - "patch"
+          - "minor"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+### Describe your change
+
+### Why was the change made
+
+### Jira ticket link
+
+### Dependencies on other pull requests
+
+### Checklist before requesting a review
+
+- [ ] I have performed a self-review of my code
+- [ ] I have added thorough tests where needed
+- [ ] I adjusted the README to reflect the change if applicable
+- [ ] I put sufficient and relevant logging statements that could help in case of debugging or security investigation if applicable


### PR DESCRIPTION
### Describe your change

This PR updates Dependabot config of NPM/PNPM and pip packages, codeowners and PR template.

### Why was the change made

To ensure we have good coverage of dependency management. 

### Jira ticket link

https://pokainc.atlassian.net/browse/INFRA-5044

### Dependencies on other pull requests
 
N/A

### Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added thorough tests where needed
- [ ] I tested the changes in dev
- [ ] I adjusted the README to reflect the change if applicable
- [ ] I put sufficient and relevant logging statements that could help in case of debugging or security investigation if applicable